### PR TITLE
Adding Calendar link to home page buttons

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 
 [Join us on Zulip]({{ zulip_url }}){ .md-button target="\_blank" }
 [Code of Conduct](./code-of-conduct.md){ .md-button }
-[Calendar](./calendar.md){ .md-button target="\_blank" }
+[Calendar](./calendar.md){ .md-button }
 
 ## What is Zulip?
 


### PR DESCRIPTION
Since there seems to be room on the line with the two buttons, why not add a third to the Calendar?