### PR TITLE
Update all-contributors contribution types

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -7,8 +7,33 @@
     "imageSize": 100,
     "commit": false,
     "commitConvention": "angular",
-    "contributors": [],
+    "contributors": [
+        {
+            "login": "VeckoTheGecko",
+            "name": "Nick Hodgskin",
+            "avatar_url": "https://avatars.githubusercontent.com/u/36369090?v=4",
+            "profile": "https://github.com/VeckoTheGecko",
+            "contributions": ["steering", "code"]
+        },
+        {
+            "login": "erikvansebille",
+            "name": "Erik van Sebille",
+            "avatar_url": "https://avatars.githubusercontent.com/u/14315062?v=4",
+            "profile": "https://www.uu.nl/staff/EvanSebille",
+            "contributions": ["steering"]
+        }
+    ],
     "contributorsPerLine": 7,
     "skipCi": true,
-    "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)"
+    "badgeTemplate": "[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)",
+    "types": {
+        "steering": {
+            "symbol": "🚣",
+            "description": "Current or previous members of the project steering team."
+        },
+        "moderation": {
+            "symbol": "💫",
+            "description": "Current or previous members of the project moderation team."
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -15,9 +15,21 @@ This project also uses `pre-commit` which you can optionally run locally (though
 
 ## Contributors
 
+We have contributors of all types - from those who've contributed to the direction of the project, code, design, feedback, and more. See below our contributors.
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/VeckoTheGecko"><img src="https://avatars.githubusercontent.com/u/36369090?v=4?s=100" width="100px;" alt="Nick Hodgskin"/><br /><sub><b>Nick Hodgskin</b></sub></a><br /><a href="#steering-VeckoTheGecko" title="Current or previous members of the project steering team.">🚣</a> <a href="https://github.com/CLAM Contributors/CLAM/commits?author=VeckoTheGecko" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.uu.nl/staff/EvanSebille"><img src="https://avatars.githubusercontent.com/u/14315062?v=4?s=100" width="100px;" alt="Erik van Sebille"/><br /><sub><b>Erik van Sebille</b></sub></a><br /><a href="#steering-erikvansebille" title="Current or previous members of the project steering team.">🚣</a></td>
+    </tr>
+  </tbody>
+</table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -112,7 +112,7 @@ We will follow this response protocol:
 If we verify abusive behaviour:
 
 - They will be removed from the CLAM Community
-    <!-- * If applicable, their employment with CLAM will be terminated. -->
+      <!-- * If applicable, their employment with CLAM will be terminated. -->
 - Their Zulip account will be deactivated, and
 - Permissions will be removed from any CLAM-related repositories and/or accounts.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,15 @@ Here is a list of the people who have contributed to the project.
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/VeckoTheGecko"><img src="https://avatars.githubusercontent.com/u/36369090?v=4?s=100" width="100px;" alt="Nick Hodgskin"/><br /><sub><b>Nick Hodgskin</b></sub></a><br /><a href="#steering-VeckoTheGecko" title="Current or previous members of the project steering team.">🚣</a> <a href="https://github.com/CLAM Contributors/CLAM/commits?author=VeckoTheGecko" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://www.uu.nl/staff/EvanSebille"><img src="https://avatars.githubusercontent.com/u/14315062?v=4?s=100" width="100px;" alt="Erik van Sebille"/><br /><sub><b>Erik van Sebille</b></sub></a><br /><a href="#steering-erikvansebille" title="Current or previous members of the project steering team.">🚣</a></td>
+    </tr>
+  </tbody>
+</table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 <!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
Added steering and moderation contribution types (using the 🚣 and 💫 emojis respectively - let me know if you have a better emoji suggestion that isn't alrready listed in the emoji key https://allcontributors.org/docs/en/emoji-key ). 